### PR TITLE
add docker healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,11 @@ services:
       - POSTGRES_DB=postgres
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
   web:
     build: .
     command: python manage.py runserver 0.0.0.0:8000
@@ -19,4 +24,5 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
     depends_on:
-      - db
+      db:
+        condition: service_healthy


### PR DESCRIPTION
Repaired issue with first "docker-compose up" run. Database was created, but it was not ready to receive connections when docker started the web-app. Now, with healthcheck docker waits with running web-app before database is good to go.